### PR TITLE
feat: RedmineCLI v0.8.2にアップデート

### DIFF
--- a/Formula/redmine.rb
+++ b/Formula/redmine.rb
@@ -1,26 +1,26 @@
 class Redmine < Formula
   desc "GitHub CLI-like tool for managing Redmine tickets"
   homepage "https://github.com/arstella-ltd/RedmineCLI"
-  version "0.8.1"
+  version "0.8.2"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.intel?
       url "https://github.com/arstella-ltd/RedmineCLI/releases/download/v#{version}/redmine-cli-#{version}-osx-x64.zip"
-      sha256 "f53144566a1b60df48f623b263bcf04b0d392cb4b6f0bdf0cb35cfa56130f2e7"
+      sha256 "b34854ab0af6d381d28ef8818c257d1280d633739ee2437ffafa18f79cdcd7c2"
     else
       url "https://github.com/arstella-ltd/RedmineCLI/releases/download/v#{version}/redmine-cli-#{version}-osx-arm64.zip"
-      sha256 "921c242f8d9edcb7b7d9aac94c64b4a1ae2d676887c62e41e6d55055a3b6e9d2"
+      sha256 "706a4d5efd312f5af736b36a775123bf87753fcd48df6dcf1e827c77aacf85a8"
     end
   end
 
   on_linux do
     if Hardware::CPU.intel?
       url "https://github.com/arstella-ltd/RedmineCLI/releases/download/v#{version}/redmine-cli-#{version}-linux-x64.zip"
-      sha256 "4bb0a956cdb13986568bb58474b6b18216bbea432c5f4adc92ce28c8874fc570"
+      sha256 "f835b25f0228405040c08926b7ec4b24db050f133f423d4a78a38abbf3155765"
     else
       url "https://github.com/arstella-ltd/RedmineCLI/releases/download/v#{version}/redmine-cli-#{version}-linux-arm64.zip"
-      sha256 "92a51f5a7cbba037fdebea23a2e3918d870420b6b0fec67afbbb99e5aea9bfd9"
+      sha256 "3502535947544a70fc399b59ac91ae31f2916cf605e53caef71cba11684c1784"
     end
   end
 


### PR DESCRIPTION
## Summary
- RedmineCLI v0.8.2のリリースに伴うFormula更新
- バージョンを0.8.1から0.8.2に更新
- 全プラットフォームのSHA256ハッシュ値を更新

## Changes
- macOS Intel: `b34854ab0af6d381d28ef8818c257d1280d633739ee2437ffafa18f79cdcd7c2`
- macOS ARM64: `706a4d5efd312f5af736b36a775123bf87753fcd48df6dcf1e827c77aacf85a8`
- Linux x64: `f835b25f0228405040c08926b7ec4b24db050f133f423d4a78a38abbf3155765`
- Linux ARM64: `3502535947544a70fc399b59ac91ae31f2916cf605e53caef71cba11684c1784`

## Test plan
- [x] `brew install arstella-ltd/tap/redmine`でインストール確認
- [x] `redmine --version`でv0.8.2が表示されることを確認