### PR TITLE
feat: Update RedmineCLI to v0.9.0

### DIFF
--- a/.github/workflows/test-formula.yml
+++ b/.github/workflows/test-formula.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Test ${{ matrix.formula }} formula installation
         run: |
           # Install directly from the checked out formula file
-          brew install --verbose --build-from-source ./Formula/${{ matrix.formula }}.rb
+          brew install --verbose ./Formula/${{ matrix.formula }}.rb
           
       - name: Verify ${{ matrix.formula }} installation
         run: |
@@ -71,7 +71,7 @@ jobs:
       - name: Test ${{ matrix.formula }} formula installation
         run: |
           # Install directly from the checked out formula file
-          brew install --verbose --build-from-source ./Formula/${{ matrix.formula }}.rb
+          brew install --verbose ./Formula/${{ matrix.formula }}.rb
           
       - name: Verify ${{ matrix.formula }} installation
         run: |

--- a/.github/workflows/test-formula.yml
+++ b/.github/workflows/test-formula.yml
@@ -17,40 +17,39 @@ jobs:
           - qx
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Homebrew
         run: |
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" || true
           echo "/opt/homebrew/bin" >> $GITHUB_PATH
           eval "$(/opt/homebrew/bin/brew shellenv)"
-          
-      - name: Test ${{ matrix.formula }} formula installation
-        run: |
-          # Install directly from the checked out formula file
-          brew install --verbose ./Formula/${{ matrix.formula }}.rb
-          
-      - name: Verify ${{ matrix.formula }} installation
-        run: |
-          which ${{ matrix.formula }}
-          ${{ matrix.formula }} --version
-          
+
       - name: Configure Git
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
-          
-      - name: Run brew test for ${{ matrix.formula }}
+
+      - name: Test ${{ matrix.formula }} formula installation
         run: |
-          # First, create a temporary tap for testing
+          # Create a temporary tap for installation and testing
           brew tap-new local/temp-test
           cp Formula/${{ matrix.formula }}.rb $(brew --repository)/Library/Taps/local/homebrew-temp-test/Formula/
+          brew install --verbose local/temp-test/${{ matrix.formula }}
+
+      - name: Verify ${{ matrix.formula }} installation
+        run: |
+          which ${{ matrix.formula }}
+          ${{ matrix.formula }} --version
+
+      - name: Run brew test for ${{ matrix.formula }}
+        run: |
           brew test local/temp-test/${{ matrix.formula }}
-          brew untap local/temp-test
-          
+
       - name: Clean up
         if: always()
         run: |
           brew uninstall ${{ matrix.formula }} || true
+          brew untap local/temp-test || true
 
   test-linux:
     runs-on: ubuntu-latest
@@ -61,40 +60,39 @@ jobs:
           - qx
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Homebrew
         run: |
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
           echo "/home/linuxbrew/.linuxbrew/bin" >> $GITHUB_PATH
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          
-      - name: Test ${{ matrix.formula }} formula installation
-        run: |
-          # Install directly from the checked out formula file
-          brew install --verbose ./Formula/${{ matrix.formula }}.rb
-          
-      - name: Verify ${{ matrix.formula }} installation
-        run: |
-          which ${{ matrix.formula }}
-          ${{ matrix.formula }} --version
-          
+
       - name: Configure Git
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
-          
-      - name: Run brew test for ${{ matrix.formula }}
+
+      - name: Test ${{ matrix.formula }} formula installation
         run: |
-          # First, create a temporary tap for testing
+          # Create a temporary tap for installation and testing
           brew tap-new local/temp-test
           cp Formula/${{ matrix.formula }}.rb $(brew --repository)/Library/Taps/local/homebrew-temp-test/Formula/
+          brew install --verbose local/temp-test/${{ matrix.formula }}
+
+      - name: Verify ${{ matrix.formula }} installation
+        run: |
+          which ${{ matrix.formula }}
+          ${{ matrix.formula }} --version
+
+      - name: Run brew test for ${{ matrix.formula }}
+        run: |
           brew test local/temp-test/${{ matrix.formula }}
-          brew untap local/temp-test
-          
+
       - name: Clean up
         if: always()
         run: |
           brew uninstall ${{ matrix.formula }} || true
+          brew untap local/temp-test || true
 
   audit-formula:
     runs-on: macos-latest
@@ -105,18 +103,18 @@ jobs:
           - qx
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Homebrew
         run: |
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" || true
           echo "/opt/homebrew/bin" >> $GITHUB_PATH
           eval "$(/opt/homebrew/bin/brew shellenv)"
-          
+
       - name: Configure Git
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
-          
+
       - name: Run brew audit for ${{ matrix.formula }}
         run: |
           # Create a temporary tap for auditing

--- a/Formula/redmine.rb
+++ b/Formula/redmine.rb
@@ -1,26 +1,26 @@
 class Redmine < Formula
   desc "GitHub CLI-like tool for managing Redmine tickets"
   homepage "https://github.com/arstella-ltd/RedmineCLI"
-  version "0.8.3"
+  version "0.9.0"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.intel?
       url "https://github.com/arstella-ltd/RedmineCLI/releases/download/v#{version}/redmine-cli-#{version}-osx-x64.zip"
-      sha256 "4999bdbeb7df8e8de9757e7612f182b55f4ed1681d6ffc6d0e1c80b0e587192b"
+      sha256 "3a6f58ebe8c1c39e280c68db31dc7775fb9e38e756720a633c5fecd859c71aa0"
     else
       url "https://github.com/arstella-ltd/RedmineCLI/releases/download/v#{version}/redmine-cli-#{version}-osx-arm64.zip"
-      sha256 "e37fbae91731a1f2c041aa34c5c0b998e5c8a20cb9bafb1019667e2f507fc8a2"
+      sha256 "943c0515b55e438ca331a8928b1aa023dd05f9d32d543fbd808e7592af461807"
     end
   end
 
   on_linux do
     if Hardware::CPU.intel?
       url "https://github.com/arstella-ltd/RedmineCLI/releases/download/v#{version}/redmine-cli-#{version}-linux-x64.zip"
-      sha256 "f96b00a4b6a25c3af342cf0e1c7058e8c43ae89649108a0f56f19152ee272127"
+      sha256 "07a6d64a0e796ff427fdfb63b37adc7c52197080b6250407df9ba62b43fb2724"
     else
       url "https://github.com/arstella-ltd/RedmineCLI/releases/download/v#{version}/redmine-cli-#{version}-linux-arm64.zip"
-      sha256 "21a54aa760f7662510aa569ddcb6929c00fa57600101c2999f02ddb3e525562e"
+      sha256 "9864342a398206770994f161cb9b2c4a1959242cad43fd4a7be9973c48b43167"
     end
   end
 


### PR DESCRIPTION
## Summary
- Update RedmineCLI version from 0.8.3 to 0.9.0
- Update SHA256 checksums for all platforms (macOS x64/arm64, Linux x64/arm64)
- Fix CI workflow to use temporary tap for formula installation

## Changes
### Formula Updates
- Bump version to 0.9.0
- Update SHA256 checksums for all platform binaries

### Workflow Improvements
- Modified test workflow to create temporary tap before installation
- Recent Homebrew versions require formulae to be in a tap
- Ensures proper testing environment for both macOS and Linux

## Test plan
- ✅ All CI tests passing (test-macos, test-linux, audit-formula)
- ✅ Formula installs successfully from tap on all platforms
- ✅ `redmine --version` confirms version 0.9.0